### PR TITLE
Release: v1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ new System()
 | @onebeyond/knex-systemic@1.1.2 | 14.x-19.x | 0.95.12 |
 | @onebeyond/knex-systemic@1.1.3 | 14.x-19.x | 0.95.13 |
 | @onebeyond/knex-systemic@1.1.4 | 14.x-19.x | 0.95.14 |
+| @onebeyond/knex-systemic@1.1.5 | 14.x-19.x | 0.95.15 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,9 +3289,9 @@
       "dev": true
     },
     "knex": {
-      "version": "0.95.14",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.14.tgz",
-      "integrity": "sha512-j4qLjWySrC/JRRVtOpoR2LcS1yBOsd7Krc6mEukPvmTDX/w11pD52Pq9FYR56/kLXGeAV8jFdWBjsZFi1mscWg==",
+      "version": "0.95.15",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.15.tgz",
+      "integrity": "sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "0.95.14"
+    "knex": "0.95.15"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main changes
- [chore: bump knex version to 0.95.15](https://github.com/onebeyond/systemic-knex/pull/14/commits/3373375dbfc7b56e479237f72d7edc8d9c440f47)
  - Changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#09515---22-december-2021