### PR TITLE
Release: v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ new System()
 | @onebeyond/knex-systemic@1.1.5 | 14.x-19.x | 0.95.15 |
 | @onebeyond/knex-systemic@2.0.0 | 14.x-19.x | 1.0.0 |
 | @onebeyond/knex-systemic@2.0.1 | 14.x-19.x | 1.0.1 |
+| @onebeyond/knex-systemic@2.0.2 | 14.x-19.x | 1.0.2 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,9 +3289,9 @@
       "dev": true
     },
     "knex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.1.tgz",
-      "integrity": "sha512-pusgMo74lEbUxmri+YfWV8x/LJacP/2KcemTCKH7WnXFYz5RoMi+8WM4OJ05b0glfF+aWB4nkFsxsXxJ8qioLQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.2.tgz",
+      "integrity": "sha512-RuDKTylj6X/3nYomnsFV8sOdxTcehLHczOd3yrUdULE4pQR8jVlZxYt3vvIU04otJF0Cw9DCtRt05S4PN4kDpw==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "1.0.1"
+    "knex": "1.0.2"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
### Main changes

- [chore: bump knex version to 1.0.2](https://github.com/onebeyond/systemic-knex/pull/17/commits/d3f96cd9401bb5f858c8b8e4214e6c4203a727e7)
  - Changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#102---02-february-2022

