### PR TITLE
Release: v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ new System()
 | @onebeyond/knex-systemic@2.0.0 | 14.x-19.x | 1.0.0 |
 | @onebeyond/knex-systemic@2.0.1 | 14.x-19.x | 1.0.1 |
 | @onebeyond/knex-systemic@2.0.2 | 14.x-19.x | 1.0.2 |
+| @onebeyond/knex-systemic@2.0.3 | 14.x-19.x | 1.0.3 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,9 +3289,9 @@
       "dev": true
     },
     "knex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.2.tgz",
-      "integrity": "sha512-RuDKTylj6X/3nYomnsFV8sOdxTcehLHczOd3yrUdULE4pQR8jVlZxYt3vvIU04otJF0Cw9DCtRt05S4PN4kDpw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.3.tgz",
+      "integrity": "sha512-rY1T7cgTQGHAUD9TshMka37bd+SEK+koPXXvZQEIoE8yjJ/E8ShsenaAmr3oaNNzqXuKD/SC0qlYtp7Js8tAXA==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "1.0.2"
+    "knex": "1.0.3"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main changes

- [chore: bump knex version to 1.0.3](https://github.com/onebeyond/systemic-knex/pull/18/commits/700b9bdf7811bcebc2f687e64a8706c05de43e82)
  -  changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#103---11-february-2022
