### PR TITLE
Release: v2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ new System()
 | @onebeyond/knex-systemic@2.0.1 | 14.x-19.x | 1.0.1 |
 | @onebeyond/knex-systemic@2.0.2 | 14.x-19.x | 1.0.2 |
 | @onebeyond/knex-systemic@2.0.3 | 14.x-19.x | 1.0.3 |
+| @onebeyond/knex-systemic@2.0.4 | 14.x-19.x | 1.0.4 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,9 +3289,9 @@
       "dev": true
     },
     "knex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.3.tgz",
-      "integrity": "sha512-rY1T7cgTQGHAUD9TshMka37bd+SEK+koPXXvZQEIoE8yjJ/E8ShsenaAmr3oaNNzqXuKD/SC0qlYtp7Js8tAXA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.4.tgz",
+      "integrity": "sha512-cMQ81fpkVmr4ia20BtyrD3oPere/ir/Q6IGLAgcREKOzRVhMsasQ4nx1VQuDRJjqq6oK5kfcxmvWoYkHKrnuMA==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "1.0.3"
+    "knex": "1.0.4"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main changes

- [Bump knex version to 1.0.4](https://github.com/onebeyond/systemic-knex/pull/19/commits/edf8ae6ea662a58392e97ae36b102cf5fb26e524)
  - Changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#104---13-march-2022
