### PR TITLE
Release: v2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ new System()
 | @onebeyond/knex-systemic@2.0.2 | 14.x-19.x | 1.0.2 |
 | @onebeyond/knex-systemic@2.0.3 | 14.x-19.x | 1.0.3 |
 | @onebeyond/knex-systemic@2.0.4 | 14.x-19.x | 1.0.4 |
+| @onebeyond/knex-systemic@2.0.5 | 14.x-19.x | 1.0.5 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1394,9 +1394,9 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1425,7 +1425,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -2122,8 +2121,7 @@
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
     },
     "get-stdin": {
       "version": "8.0.0",
@@ -3289,15 +3287,16 @@
       "dev": true
     },
     "knex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.4.tgz",
-      "integrity": "sha512-cMQ81fpkVmr4ia20BtyrD3oPere/ir/Q6IGLAgcREKOzRVhMsasQ4nx1VQuDRJjqq6oK5kfcxmvWoYkHKrnuMA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.5.tgz",
+      "integrity": "sha512-EPEQNA0Yn5H5yoqKuCpdGn1EmispA/wS7OMaCAmirHlvHpiZUqcTerD9OU71t3nVLSnuXa0nYcnkUtRSPchsnA==",
       "requires": {
         "colorette": "2.0.16",
-        "commander": "^8.3.0",
-        "debug": "4.3.3",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
+        "get-package-type": "^0.1.0",
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
@@ -3308,14 +3307,6 @@
         "tildify": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "1.0.4"
+    "knex": "1.0.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main Changes

- [chore: bump knex version to 1.0.5](https://github.com/onebeyond/systemic-knex/pull/20/commits/6759c26453b1ef37e7dace0e9e25099b04a31f2a)
  - Changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#105---05-april-2022
