### PR TITLE
Release: v2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ new System()
 | @onebeyond/knex-systemic@2.0.3 | 14.x-19.x | 1.0.3 |
 | @onebeyond/knex-systemic@2.0.4 | 14.x-19.x | 1.0.4 |
 | @onebeyond/knex-systemic@2.0.5 | 14.x-19.x | 1.0.5 |
+| @onebeyond/knex-systemic@2.0.6 | 14.x-19.x | 1.0.6 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3287,9 +3287,9 @@
       "dev": true
     },
     "knex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.5.tgz",
-      "integrity": "sha512-EPEQNA0Yn5H5yoqKuCpdGn1EmispA/wS7OMaCAmirHlvHpiZUqcTerD9OU71t3nVLSnuXa0nYcnkUtRSPchsnA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.6.tgz",
+      "integrity": "sha512-J9jYxo0ttDJz6fCfWaBrQ16mkXQvh/FjNL+7x11IqCy/2nq8vpv1MWMBPMK9UwXYiTPdn/EU4bg1KP6eXjOVEA==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "1.0.5"
+    "knex": "1.0.6"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
### Main changes
- [chore: bump knex version to 1.0.6](https://github.com/onebeyond/systemic-knex/pull/21/commits/defe3a2fcade8acc2f43f39935bb9eea012f736d)
  - Changelog https://github.com/knex/knex/blob/master/CHANGELOG.md#106---12-april-2022
