### PR TITLE
Release: v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ new System()
 | @onebeyond/knex-systemic@3.0.0 | 14.x-19.x | 2.0.0 |
 | @onebeyond/knex-systemic@3.1.0 | 14.x-19.x | 2.1.0 |
 | @onebeyond/knex-systemic@3.2.0 | 14.x-19.x | 2.2.0 |
+| @onebeyond/knex-systemic@3.3.0 | 14.x-19.x | 2.3.0 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3287,9 +3287,9 @@
       "dev": true
     },
     "knex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.2.0.tgz",
-      "integrity": "sha512-yhm1Qe9Ok0TeXBq3nNHqZYJPrQ4Iw2tq9k/HxjrZ/EWec2ifOjJlkNHr26v8cQrWtk5iG3iwfUazTIWy+VKG5g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.3.0.tgz",
+      "integrity": "sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==",
       "requires": {
         "colorette": "2.0.19",
         "commander": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "2.2.0"
+    "knex": "2.3.0"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
### Main changes

- [Bump knex version to 2.3.0](https://github.com/onebeyond/systemic-knex/pull/27/commits/a0b33a0f9b360ba7f27f419f9ec1c2cbceb03bc7)
  -  changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#230---31-august-2022