### PR TITLE
Release: v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ new System()
 | @onebeyond/knex-systemic@3.2.0 | 14.x-19.x | 2.2.0 |
 | @onebeyond/knex-systemic@3.3.0 | 14.x-19.x | 2.3.0 |
 | @onebeyond/knex-systemic@3.4.0 | 14.x-19.x | 2.4.0 |
+| @onebeyond/knex-systemic@3.4.1 | 14.x-19.x | 2.4.1 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3287,9 +3287,9 @@
       "dev": true
     },
     "knex": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.0.tgz",
-      "integrity": "sha512-i0GWwqYp1Hs2yvc2rlDO6nzzkLhwdyOZKRdsMTB8ZxOs2IXQyL5rBjSbS1krowCh6V65T4X9CJaKtuIfkaPGSA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.1.tgz",
+      "integrity": "sha512-5wylehvnTOE8EdypPFakccA1zgo6Lp+TNultncvBUCUD0PasY+PLVa9qPrTFCioxPSPVha1u9ye2niAVVbLM0Q==",
       "requires": {
         "colorette": "2.0.19",
         "commander": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "2.4.0"
+    "knex": "2.4.1"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main changes

- [Bump knex version to 2.4.1](https://github.com/onebeyond/systemic-knex/pull/30/commits/b3e38833520035c35f1efb529fb3385afdc61c0e)
  - changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#241---18-january-2022
