### PR TITLE
Release: v3.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ new System()
 | @onebeyond/knex-systemic@3.3.0 | 14.x-19.x | 2.3.0 |
 | @onebeyond/knex-systemic@3.4.0 | 14.x-19.x | 2.4.0 |
 | @onebeyond/knex-systemic@3.4.1 | 14.x-19.x | 2.4.1 |
+| @onebeyond/knex-systemic@3.4.2 | 14.x-19.x | 2.4.2 |
 
 ### 📚 Parameters
 Check out [the official documentation](http://knexjs.org/#Installation-client)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3287,9 +3287,9 @@
       "dev": true
     },
     "knex": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.1.tgz",
-      "integrity": "sha512-5wylehvnTOE8EdypPFakccA1zgo6Lp+TNultncvBUCUD0PasY+PLVa9qPrTFCioxPSPVha1u9ye2niAVVbLM0Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
+      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
       "requires": {
         "colorette": "2.0.19",
         "commander": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebeyond/systemic-knex",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A systemic Knex component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/onebeyond/systemic-knex#readme",
   "dependencies": {
-    "knex": "2.4.1"
+    "knex": "2.4.2"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
### Main changes

- [Bump knex version to 2.4.2](https://github.com/onebeyond/systemic-knex/pull/32/commits/9455d886e25f38e0eb9999f4631f5cc99d1a539f)
  - changelog: https://github.com/knex/knex/blob/master/CHANGELOG.md#242---22-january-2022
