### PR TITLE
Update firewall rules in github worflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,8 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
             nodejs.org:443
+            *.actions.githubusercontent.com:443
+            actions.githubusercontent.com:443
             *.githubapp.com:443
             githubapp.com:443
       - name: ⚙️ Git Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,8 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
             nodejs.org:443
+            *.githubapp.com:443
+            githubapp.com:443
       - name: ⚙️ Git Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: ⚙️ Install Node@20


### PR DESCRIPTION
### Main Changes
Enable traffic to:
- `*.actions.githubusercontent.com:443`
- `actions.githubusercontent.com:443`
- `*.githubapp.com:443`
- `githubapp.com:443`

### Related

Ci failure in https://github.com/onebeyond/systemic-knex/actions/runs/6942548100/job/18885789053
![Screenshot 2023-11-21 at 12 28 09](https://github.com/onebeyond/systemic-knex/assets/5110813/372f58b1-d9f4-4ad4-a81d-df4389fa1b9b)

